### PR TITLE
feat(extension) More memory view types, and better errors

### DIFF
--- a/examples/memory.py
+++ b/examples/memory.py
@@ -7,7 +7,7 @@ wasm_bytes = open(__dir__ + '/memory.wasm', 'rb').read()
 instance = Instance(wasm_bytes)
 pointer = instance.call('return_hello')
 
-memory = instance.memory_view(pointer)
+memory = instance.uint8_memory_view(pointer)
 nth = 0;
 string = '';
 

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ test:
 
 # Inspect the `python-ext-wasm` extension.
 inspect:
-	.env/bin/python -c "help('wasm')"
+	.env/bin/python -c "help('wasmer')"
 
 # Local Variables:
 # mode: makefile

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ mod memory_view;
 mod value;
 
 use instance::{validate, Instance};
-use memory_view::MemoryView;
 use value::Value;
 
 /// A `Shell` is a thread-safe wrapper over a value `T` that will fail
@@ -62,7 +61,12 @@ py_module_initializer!(libwasmer, initlibwasmer, PyInit_wasmer, |python, module|
         "__doc__",
         "This extension allows to manipulate and to execute WebAssembly binaries.",
     )?;
-    module.add_class::<MemoryView>(python)?;
+    module.add_class::<memory_view::Uint8MemoryView>(python)?;
+    module.add_class::<memory_view::Int8MemoryView>(python)?;
+    module.add_class::<memory_view::Uint16MemoryView>(python)?;
+    module.add_class::<memory_view::Int16MemoryView>(python)?;
+    module.add_class::<memory_view::Uint32MemoryView>(python)?;
+    module.add_class::<memory_view::Int32MemoryView>(python)?;
     module.add_class::<Instance>(python)?;
     module.add_class::<Value>(python)?;
     module.add(python, "validate", py_fn!(python, validate(bytes: PyBytes)))?;

--- a/src/memory_view.rs
+++ b/src/memory_view.rs
@@ -41,10 +41,24 @@ macro_rules! memory_view {
 
             def set(&self, index: usize, value: $wasm_type) -> PyResult<PyObject> {
                 let offset = *self.offset(py);
+                let view = self.memory(py).view::<$wasm_type>();
 
-                self.memory(py).view::<$wasm_type>()[offset + index].set(value);
+                if view.len() <= offset + index {
+                    Err(
+                        new_runtime_error(
+                            py,
+                            &format!(
+                                "Out of bound: Absolute index {} is larger than the memory size {}.",
+                                offset + index,
+                                view.len()
+                            )
+                        )
+                    )
+                } else {
+                    view[offset + index].set(value);
 
-                Ok(Python::None(py))
+                    Ok(Python::None(py))
+                }
             }
         });
 

--- a/tests/instance.py
+++ b/tests/instance.py
@@ -1,4 +1,4 @@
-from wasmer import Instance, MemoryView, Value, validate
+from wasmer import Instance, Uint8MemoryView, Value, validate
 import inspect
 import os
 import unittest
@@ -114,4 +114,4 @@ class TestWasmInstance(unittest.TestCase):
         self.assertFalse(validate(INVALID_TEST_BYTES))
 
     def test_memory_view(self):
-        self.assertIsInstance(Instance(TEST_BYTES).memory_view(), MemoryView)
+        self.assertIsInstance(Instance(TEST_BYTES).uint8_memory_view(), Uint8MemoryView)

--- a/tests/memory_view.py
+++ b/tests/memory_view.py
@@ -1,4 +1,4 @@
-from wasmer import Instance, MemoryView
+from wasmer import Instance, Uint8MemoryView, Int8MemoryView, Uint16MemoryView, Int16MemoryView, Uint32MemoryView, Int32MemoryView
 import inspect
 import os
 import unittest
@@ -8,20 +8,25 @@ TEST_BYTES = open(here + '/tests.wasm', 'rb').read()
 
 class TestWasmMemoryView(unittest.TestCase):
     def test_is_a_class(self):
-        self.assertTrue(inspect.isclass(Instance))
+        self.assertTrue(inspect.isclass(Uint8MemoryView))
+        self.assertTrue(inspect.isclass(Int8MemoryView))
+        self.assertTrue(inspect.isclass(Uint16MemoryView))
+        self.assertTrue(inspect.isclass(Int16MemoryView))
+        self.assertTrue(inspect.isclass(Uint32MemoryView))
+        self.assertTrue(inspect.isclass(Int32MemoryView))
 
     @unittest.expectedFailure
     def test_cannot_construct(self):
-        self.assertIsInstance(MemoryView(0), MemoryView)
+        self.assertIsInstance(Uint8MemoryView(0), Uint8MemoryView)
 
     def test_length(self):
         self.assertEqual(
-            Instance(TEST_BYTES).memory_view().length(),
+            Instance(TEST_BYTES).uint8_memory_view().length(),
             1114112
         )
 
     def test_get(self):
-        memory = Instance(TEST_BYTES).memory_view()
+        memory = Instance(TEST_BYTES).uint8_memory_view()
         index = 7
         value = 42
         memory.set(index, value)
@@ -30,14 +35,14 @@ class TestWasmMemoryView(unittest.TestCase):
 
     def test_set_returns_none(self):
         self.assertEqual(
-            Instance(TEST_BYTES).memory_view().set(7, 42),
+            Instance(TEST_BYTES).uint8_memory_view().set(7, 42),
             None
         )
 
     def test_hello_world(self):
         instance = Instance(TEST_BYTES)
         pointer = instance.call('string')
-        memory = instance.memory_view(pointer)
+        memory = instance.uint8_memory_view(pointer)
         nth = 0
         string = ''
 

--- a/tests/memory_view.py
+++ b/tests/memory_view.py
@@ -50,6 +50,17 @@ class TestWasmMemoryView(unittest.TestCase):
             None
         )
 
+    def test_set_out_of_range(self):
+        with self.assertRaises(RuntimeError) as context_manager:
+            memory = Instance(TEST_BYTES).uint8_memory_view()
+            memory.set(memory.length() + 1, 42)
+
+        exception = context_manager.exception
+        self.assertEqual(
+            str(exception),
+            'Out of bound: Absolute index 1114113 is larger than the memory size 1114112.'
+        )
+
     def test_hello_world(self):
         instance = Instance(TEST_BYTES)
         pointer = instance.call('string')


### PR DESCRIPTION
This patch does 2 things:

  1. Add more memory view types (with `uint8`, `int8`, `uint16`, `int16`, `uint32` and `int32`),
  2. Check whether get and set are inside the range of the memory size.