### PR TITLE
feat(extension) Better Python API for `*MemoryView`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ value_f64 = Value.f64(7.42)
 The `Value.[if](32|64)` static methods must be considered as static
 constructors.
 
-The `to_string` method allows to get a string representation of a
+The `__repr__` method allows to get a string representation of a
 `Value` instance:
 
 ```python
-print(value_i32) # I32(7)
+print(repr(value_i32)) # I32(7)
 ```
 
 ### The `*MemoryView` classes
@@ -158,8 +158,8 @@ memory = instance.uint8_memory_view(pointer)
 nth = 0;
 string = ''
 
-while (0 != memory.get(nth)):
-    string += chr(memory.get(nth))
+while (0 != memory[nth]):
+    string += chr(memory[nth])
     nth += 1
 
 print(string) # Hello, World!

--- a/examples/memory.py
+++ b/examples/memory.py
@@ -11,8 +11,8 @@ memory = instance.uint8_memory_view(pointer)
 nth = 0;
 string = '';
 
-while (0 != memory.get(nth)):
-    string += chr(memory.get(nth))
+while (0 != memory[nth]):
+    string += chr(memory[nth])
     nth += 1
 
 print('"' + string + '"') # "Hello, World!"

--- a/src/memory_view.rs
+++ b/src/memory_view.rs
@@ -1,7 +1,7 @@
 //! The `Buffer` Python object to build WebAssembly values.
 
 use crate::{error::new_runtime_error, Shell};
-use cpython::{PyObject, PyResult, Python};
+use cpython::{PyResult, Python};
 use std::mem::size_of;
 use wasmer_runtime::memory::Memory;
 
@@ -39,7 +39,7 @@ macro_rules! memory_view {
                 }
             }
 
-            def set(&self, index: usize, value: $wasm_type) -> PyResult<PyObject> {
+            def __setitem__(&self, index: usize, value: $wasm_type) -> PyResult<()> {
                 let offset = *self.offset(py);
                 let view = self.memory(py).view::<$wasm_type>();
 
@@ -57,7 +57,7 @@ macro_rules! memory_view {
                 } else {
                     view[offset + index].set(value);
 
-                    Ok(Python::None(py))
+                    Ok(())
                 }
             }
         });

--- a/src/memory_view.rs
+++ b/src/memory_view.rs
@@ -13,7 +13,7 @@ macro_rules! memory_view {
             data memory: Shell<Memory>;
             data offset: usize;
 
-            def length(&self) -> PyResult<usize> {
+            def __len__(&self) -> PyResult<usize> {
                 let offset = *self.offset(py);
 
                 Ok(self.memory(py).view::<$wasm_type>()[offset..].len() / size_of::<$wasm_type>())

--- a/src/memory_view.rs
+++ b/src/memory_view.rs
@@ -19,7 +19,7 @@ macro_rules! memory_view {
                 Ok(self.memory(py).view::<$wasm_type>()[offset..].len() / size_of::<$wasm_type>())
             }
 
-            def get(&self, index: usize) -> PyResult<$wasm_type> {
+            def __getitem__(&self, index: usize) -> PyResult<$wasm_type> {
                 let offset = *self.offset(py);
                 let view = self.memory(py).view::<$wasm_type>();
 

--- a/tests/memory_view.py
+++ b/tests/memory_view.py
@@ -29,7 +29,7 @@ class TestWasmMemoryView(unittest.TestCase):
         memory = Instance(TEST_BYTES).uint8_memory_view()
         index = 7
         value = 42
-        memory.set(index, value)
+        memory[index] = value
 
         self.assertEqual(memory[index], value)
 
@@ -44,16 +44,10 @@ class TestWasmMemoryView(unittest.TestCase):
             'Out of bound: Absolute index 1114113 is larger than the memory size 1114112.'
         )
 
-    def test_set_returns_none(self):
-        self.assertEqual(
-            Instance(TEST_BYTES).uint8_memory_view().set(7, 42),
-            None
-        )
-
     def test_set_out_of_range(self):
         with self.assertRaises(RuntimeError) as context_manager:
             memory = Instance(TEST_BYTES).uint8_memory_view()
-            memory.set(len(memory) + 1, 42)
+            memory[len(memory) + 1] = 42
 
         exception = context_manager.exception
         self.assertEqual(
@@ -80,10 +74,10 @@ class TestWasmMemoryView(unittest.TestCase):
         int16 = instance.int16_memory_view()
         int32 = instance.int32_memory_view()
 
-        int8.set(0, 0b00000001)
-        int8.set(1, 0b00000100)
-        int8.set(2, 0b00010000)
-        int8.set(3, 0b01000000)
+        int8[0] = 0b00000001
+        int8[1] = 0b00000100
+        int8[2] = 0b00010000
+        int8[3] = 0b01000000
 
         self.assertEqual(int8[0], 0b00000001)
         self.assertEqual(int8[1], 0b00000100)

--- a/tests/memory_view.py
+++ b/tests/memory_view.py
@@ -31,12 +31,12 @@ class TestWasmMemoryView(unittest.TestCase):
         value = 42
         memory.set(index, value)
 
-        self.assertEqual(memory.get(index), value)
+        self.assertEqual(memory[index], value)
 
     def test_get_out_of_range(self):
         with self.assertRaises(RuntimeError) as context_manager:
             memory = Instance(TEST_BYTES).uint8_memory_view()
-            memory.get(len(memory) + 1)
+            memory[len(memory) + 1]
 
         exception = context_manager.exception
         self.assertEqual(
@@ -68,8 +68,8 @@ class TestWasmMemoryView(unittest.TestCase):
         nth = 0
         string = ''
 
-        while (0 != memory.get(nth)):
-            string += chr(memory.get(nth))
+        while (0 != memory[nth]):
+            string += chr(memory[nth])
             nth += 1
 
         self.assertEqual(string, 'Hello, World!')
@@ -85,10 +85,10 @@ class TestWasmMemoryView(unittest.TestCase):
         int8.set(2, 0b00010000)
         int8.set(3, 0b01000000)
 
-        self.assertEqual(int8.get(0), 0b00000001)
-        self.assertEqual(int8.get(1), 0b00000100)
-        self.assertEqual(int8.get(2), 0b00010000)
-        self.assertEqual(int8.get(3), 0b01000000)
-        self.assertEqual(int16.get(0), 0b00000100_00000001)
-        self.assertEqual(int16.get(1), 0b01000000_00010000)
-        self.assertEqual(int32.get(0), 0b01000000_00010000_00000100_00000001)
+        self.assertEqual(int8[0], 0b00000001)
+        self.assertEqual(int8[1], 0b00000100)
+        self.assertEqual(int8[2], 0b00010000)
+        self.assertEqual(int8[3], 0b01000000)
+        self.assertEqual(int16[0], 0b00000100_00000001)
+        self.assertEqual(int16[1], 0b01000000_00010000)
+        self.assertEqual(int32[0], 0b01000000_00010000_00000100_00000001)

--- a/tests/memory_view.py
+++ b/tests/memory_view.py
@@ -21,7 +21,7 @@ class TestWasmMemoryView(unittest.TestCase):
 
     def test_length(self):
         self.assertEqual(
-            Instance(TEST_BYTES).uint8_memory_view().length(),
+            len(Instance(TEST_BYTES).uint8_memory_view()),
             1114112
         )
 
@@ -36,7 +36,7 @@ class TestWasmMemoryView(unittest.TestCase):
     def test_get_out_of_range(self):
         with self.assertRaises(RuntimeError) as context_manager:
             memory = Instance(TEST_BYTES).uint8_memory_view()
-            memory.get(memory.length() + 1)
+            memory.get(len(memory) + 1)
 
         exception = context_manager.exception
         self.assertEqual(
@@ -53,7 +53,7 @@ class TestWasmMemoryView(unittest.TestCase):
     def test_set_out_of_range(self):
         with self.assertRaises(RuntimeError) as context_manager:
             memory = Instance(TEST_BYTES).uint8_memory_view()
-            memory.set(memory.length() + 1, 42)
+            memory.set(len(memory) + 1, 42)
 
         exception = context_manager.exception
         self.assertEqual(


### PR DESCRIPTION
This patch does the following:

  * Replace `length` by `__len__`,
  * Replace `get` by `__getitem__`,
  * Replace `set` by `__setitem__`.

The result feels more Python. Before:

```python
while (0 != memory.get(nth)):
    string += chr(memory.get(nth))
    nth += 1

…

memory.length()
```

After:

```python
while (0 != memory[nth]):
    string += chr(memory[nth])
    nth += 1

…

len(memory)
```