### PR TITLE
feat(extension) Support slices as indices for `Memory.__getitem__`

### DIFF
--- a/examples/memory.py
+++ b/examples/memory.py
@@ -11,8 +11,14 @@ memory = instance.memory.uint8_view(pointer)
 nth = 0;
 string = '';
 
-while (0 != memory[nth]):
-    string += chr(memory[nth])
+while True:
+    char = memory[nth]
+
+    if char == 0:
+        break;
+
+    string += chr(char)
     nth += 1
 
 print('"' + string + '"') # "Hello, World!"
+print('"' + ''.join(map(chr, memory[0:13])) + '"')

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -32,22 +32,71 @@ def test_length():
         1114112
     )
 
-def test_get():
+def test_get_index():
     memory = Instance(TEST_BYTES).memory.uint8_view()
     index = 7
     value = 42
     memory[index] = value
 
-    assert memory[index] ==  value
+    assert memory[index] == value
 
-def test_get_out_of_range():
+def test_get_integer_out_of_range_too_large():
     with pytest.raises(IndexError) as context_manager:
         memory = Instance(TEST_BYTES).memory.uint8_view()
         memory[len(memory) + 1]
 
     exception = context_manager.value
     assert str(exception) == (
-        'Out of bound: Absolute index 1114113 is larger than the memory size 1114112.'
+        'Out of bound: Maximum index 1114113 is larger than the memory size 1114112.'
+    )
+
+def test_get_integer_out_of_range_negative():
+    with pytest.raises(IndexError) as context_manager:
+        memory = Instance(TEST_BYTES).memory.uint8_view()
+        memory[-1]
+
+    exception = context_manager.value
+    assert str(exception) == (
+        'Out of bound: Index cannot be negative.'
+    )
+
+def test_get_slice():
+    memory = Instance(TEST_BYTES).memory.uint8_view()
+    index = 7
+    memory[index    ] = 1
+    memory[index + 1] = 2
+    memory[index + 2] = 3
+
+    assert memory[index:index + 3] == [1, 2, 3]
+
+def test_get_slice_out_of_range_empty():
+    with pytest.raises(IndexError) as context_manager:
+        memory = Instance(TEST_BYTES).memory.uint8_view()
+        memory[2:1]
+
+    exception = context_manager.value
+    assert str(exception) == (
+        'Slice `2:1` cannot be empty.'
+    )
+
+def test_get_slice_out_of_range_invalid_step():
+    with pytest.raises(IndexError) as context_manager:
+        memory = Instance(TEST_BYTES).memory.uint8_view()
+        memory[1:7:2]
+
+    exception = context_manager.value
+    assert str(exception) == (
+        'Slice must have a step of 1 for now; given 2.'
+    )
+
+def test_get_invalid_index():
+    with pytest.raises(ValueError) as context_manager:
+        memory = Instance(TEST_BYTES).memory.uint8_view()
+        memory['a']
+
+    exception = context_manager.value
+    assert str(exception) == (
+        'Only integers and slices are valid to represent an index.'
     )
 
 def test_set_out_of_range():


### PR DESCRIPTION
WIP

  * `memory[7]` reads 1 cell of the memory at offset + 7,
  * `memory[7:13]` reads 6 cells of the memory at offset + 7.