### PR TITLE
feat(extension) Implement `__version__` for module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use value::Value;
 #[pymodule]
 fn wasmer(_py: Python, module: &PyModule) -> PyResult<()> {
     module.add_wrapped(wrap_pyfunction!(validate))?;
+    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     module.add_class::<Instance>()?;
     module.add_class::<Value>()?;
     module.add_class::<memory::Memory>()?;

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,3 +1,4 @@
+import wasmer
 from wasmer import Instance, Uint8Array, Value, validate
 import inspect
 import os
@@ -12,6 +13,9 @@ def value_with_type(value):
 
 def test_is_a_class():
     assert inspect.isclass(Instance)
+
+def test_version():
+    assert isinstance(wasmer.__version__, str)
 
 def test_can_construct():
     assert isinstance(Instance(TEST_BYTES), Instance)


### PR DESCRIPTION
It is useful to access the version string of the Python package (same as the crate) from Python, for example:
```
>>> import wasmer
>>> wasmer.__version__
'0.2.0'
```
Added a test.

I will be glad to make the entire module more pythonic if it can help, adding more useful magic methods.