### PR TITLE
feat(module) Introduce the `Module` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,41 @@ view = instance.memory.uint8_view()
 
 See below for more information.
 
+## The `Module` class
+
+Compiles a sequence of bytes into a WebAssembly module. From here, it
+is possible to instantiate it:
+
+```python
+from wasmer import Module
+
+# Get the Wasm bytes.
+wasm_bytes = open('my_program.wasm', 'rb').read()
+
+# Compile the Wasm bytes into a Wasm module.
+module = Module(wasm_bytes)
+
+# Instantiate the Wasm module.
+instance = module.instantiate()
+
+# Call a function on it.
+result = instance.exports.sum(1, 2)
+
+print(result) # 3
+```
+
+The `Module.validate` static method check whether the given bytes
+represent valid WebAssembly bytes:
+
+```python
+from wasmer import Module
+
+wasm_bytes = open('my_program.wasm', 'rb').read()
+
+if not Module.validate(wasm_bytes):
+    print('The program seems corrupted.')
+```
+
 ## The `Value` class
 
 Builds WebAssembly values with the correct types:
@@ -281,21 +316,6 @@ assert int16[1] == 0b01000000_00010000
                      ┌┬┬┬┬┬┬┐ ┌┬┬┬┬┬┬┐ ┌┬┬┬┬┬┬┐ ┌┬┬┬┬┬┬┐
 assert int32[0] == 0b01000000_00010000_00000100_00000001
 ```
-
-## The `validate` function
-
-Checks whether the given bytes represent valid WebAssembly bytes:
-
-```python
-from wasmer import validate
-
-wasm_bytes = open('my_program.wasm', 'rb').read()
-
-if not validate(wasm_bytes):
-    print('The program seems corrupted.')
-```
-
-This function returns a boolean.
 
 # Development
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -139,10 +139,10 @@ impl ExportedFunction {
 /// ```
 pub struct ExportedFunctions {
     /// The underlying Rust WebAssembly instance.
-    instance: Rc<runtime::Instance>,
+    pub(crate) instance: Rc<runtime::Instance>,
 
     /// Available exported function names from the WebAssembly module.
-    functions: Vec<String>,
+    pub(crate) functions: Vec<String>,
 }
 
 #[pyproto]
@@ -183,11 +183,11 @@ impl PyObjectProtocol for ExportedFunctions {
 pub struct Instance {
     /// All WebAssembly exported functions represented by an
     /// `ExportedFunctions` object.
-    exports: Py<ExportedFunctions>,
+    pub(crate) exports: Py<ExportedFunctions>,
 
     /// The WebAssembly exported memory represented by a `Memory`
     /// object.
-    memory: Py<Memory>,
+    pub(crate) memory: Py<Memory>,
 }
 
 #[pymethods]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,22 @@
 #![deny(warnings)]
 
-use pyo3::{
-    prelude::*,
-    types::{PyAny, PyBytes},
-    wrap_pyfunction, PyTryFrom,
-};
-use wasmer_runtime::validate as wasm_validate;
+use pyo3::prelude::*;
 
 mod instance;
 mod memory;
+mod module;
 mod value;
 
 use instance::Instance;
+use module::Module;
 use value::Value;
 
 /// This extension allows to manipulate and to execute WebAssembly binaries.
 #[pymodule]
 fn wasmer(_py: Python, module: &PyModule) -> PyResult<()> {
-    module.add_wrapped(wrap_pyfunction!(validate))?;
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     module.add_class::<Instance>()?;
+    module.add_class::<Module>()?;
     module.add_class::<Value>()?;
     module.add_class::<memory::Memory>()?;
     module.add_class::<memory::view::Int16Array>()?;
@@ -30,16 +27,4 @@ fn wasmer(_py: Python, module: &PyModule) -> PyResult<()> {
     module.add_class::<memory::view::Uint8Array>()?;
 
     Ok(())
-}
-
-/// validate(bytes, /)
-/// --
-///
-/// Check a WebAssembly module is valid.
-#[pyfunction]
-pub fn validate(bytes: &PyAny) -> PyResult<bool> {
-    match <PyBytes as PyTryFrom>::try_from(bytes) {
-        Ok(bytes) => Ok(wasm_validate(bytes.as_bytes())),
-        _ => Ok(false),
-    }
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,0 +1,24 @@
+//! The `wasmer.Module` Python object to build WebAssembly modules.
+
+use pyo3::{
+    prelude::*,
+    types::{PyAny, PyBytes},
+};
+use wasmer_runtime::validate;
+
+#[pyclass]
+/// `Module` is a Python class that represents a WebAssembly module.
+pub struct Module {}
+
+#[pymethods]
+/// Implement methods on the `Module` Python class.
+impl Module {
+    /// Check that given bytes represent a valid WebAssembly module.
+    #[staticmethod]
+    fn validate(bytes: &PyAny) -> PyResult<bool> {
+        match <PyBytes as PyTryFrom>::try_from(bytes) {
+            Ok(bytes) => Ok(validate(bytes.as_bytes())),
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,18 +1,91 @@
 //! The `wasmer.Module` Python object to build WebAssembly modules.
 
+use crate::{
+    instance::{ExportedFunctions, Instance},
+    memory::Memory,
+};
 use pyo3::{
+    exceptions::RuntimeError,
     prelude::*,
     types::{PyAny, PyBytes},
+    PyTryFrom,
 };
-use wasmer_runtime::validate;
+use std::rc::Rc;
+use wasmer_runtime::{self as runtime, imports, validate, Export};
 
 #[pyclass]
 /// `Module` is a Python class that represents a WebAssembly module.
-pub struct Module {}
+pub struct Module {
+    /// The underlying Rust WebAssembly module.
+    #[allow(unused)]
+    module: runtime::Module,
+}
 
 #[pymethods]
 /// Implement methods on the `Module` Python class.
 impl Module {
+    /// Compile bytes into a WebAssembly module.
+    #[new]
+    fn new(object: &PyRawObject, bytes: &PyAny) -> PyResult<()> {
+        // Read the bytes.
+        let bytes = <PyBytes as PyTryFrom>::try_from(bytes)?.as_bytes();
+        let module = runtime::compile(bytes).map_err(|error| {
+            RuntimeError::py_err(format!("Failed to compile the module:\n    {}", error))
+        })?;
+
+        // Instantiate the `Module` Python clas.
+        object.init({ Self { module } });
+
+        Ok(())
+    }
+
+    // Instantiate the module into an `Instance` Python object.
+    fn instantiate(&self, py: Python) -> PyResult<Py<Instance>> {
+        let imports = imports! {};
+        let instance = match self.module.instantiate(&imports) {
+            Ok(instance) => Rc::new(instance),
+            Err(e) => {
+                return Err(RuntimeError::py_err(format!(
+                    "Failed to instantiate the module:\n    {}",
+                    e
+                )))
+            }
+        };
+
+        // Collect the exported functions from the WebAssembly module.
+        let mut exported_functions = Vec::new();
+
+        for (export_name, export) in instance.exports() {
+            if let Export::Function { .. } = export {
+                exported_functions.push(export_name);
+            }
+        }
+
+        // Collect the exported memory from the WebAssembly module.
+        let memory = instance
+            .exports()
+            .find_map(|(_, export)| match export {
+                Export::Memory(memory) => Some(Rc::new(memory)),
+                _ => None,
+            })
+            .ok_or_else(|| RuntimeError::py_err("No memory exported."))?;
+
+        // Instantiate the `Instance` Python class.
+        Ok(Py::new(
+            py,
+            Instance {
+                exports: Py::new(
+                    py,
+                    ExportedFunctions {
+                        instance: instance.clone(),
+                        functions: exported_functions,
+                    },
+                )?,
+                memory: Py::new(py, Memory { memory })?,
+            },
+        )?)
+    }
+
     /// Check that given bytes represent a valid WebAssembly module.
     #[staticmethod]
     fn validate(bytes: &PyAny) -> PyResult<bool> {

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,5 +1,5 @@
 import wasmer
-from wasmer import Instance, Uint8Array, Value, validate
+from wasmer import Instance, Uint8Array, Value
 import inspect
 import os
 import pytest
@@ -67,12 +67,6 @@ def test_call_string():
 
 def test_call_void():
     assert Instance(TEST_BYTES).exports.void() == None
-
-def test_validate():
-    assert validate(TEST_BYTES)
-
-def test_validate_invalid():
-    assert not validate(INVALID_TEST_BYTES)
 
 def test_memory_view():
     assert isinstance(Instance(TEST_BYTES).memory.uint8_view(), Uint8Array)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -13,3 +13,18 @@ def test_validate():
 
 def test_validate_invalid():
     assert not Module.validate(INVALID_TEST_BYTES)
+
+def test_compile():
+    assert isinstance(Module(TEST_BYTES), Module)
+
+def test_failed_to_compile():
+    with pytest.raises(RuntimeError) as context_manager:
+        Module(INVALID_TEST_BYTES)
+
+    exception = context_manager.value
+    assert str(exception) == (
+        'Failed to compile the module:\n    Validation error "Invalid type"'
+    )
+
+def test_instantiate():
+    assert Module(TEST_BYTES).instantiate().exports.sum(1, 2) == 3

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,15 @@
+import wasmer
+from wasmer import Module
+import inspect
+import os
+import pytest
+
+here = os.path.dirname(os.path.realpath(__file__))
+TEST_BYTES = open(here + '/tests.wasm', 'rb').read()
+INVALID_TEST_BYTES = open(here + '/invalid.wasm', 'rb').read()
+
+def test_validate():
+    assert Module.validate(TEST_BYTES)
+
+def test_validate_invalid():
+    assert not Module.validate(INVALID_TEST_BYTES)


### PR DESCRIPTION
The `Module` class provides:

  1. `__init__` to compile a sequence of bytes into a WebAssembly module,
  2. `instantiate` to instantiate a module (and get an `Instance` object),
  3. `validate` —a static method— to check whether the given bytes represent a valid WebAssembly module.