### PR TITLE
feat(module) Implement `Module.serialize` and `Module.deserialize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ from wasmer import Module
 # Get the Wasm bytes.
 wasm_bytes = open('my_program.wasm', 'rb').read()
 
-# Compile the Wasm bytes into a Wasm module.
+# Compile the bytes into a Wasm module.
 module = Module(wasm_bytes)
 
 # Instantiate the Wasm module.
@@ -132,6 +132,38 @@ result = instance.exports.sum(1, 2)
 
 print(result) # 3
 ```
+
+The `Module.serialize` method and its complementary
+`Module.deserialize` static method help to respectively serialize and
+deserialize a compiled WebAssembly module, thus saving the compilation
+time for the next use:
+
+```python
+from wasmer import Module
+
+# Get the Wasm bytes.
+wasm_bytes = open('my_program.wasm', 'rb').read()
+
+# Compile the bytes into a Wasm module.
+module1 = Module(wasm_bytes)
+
+# Serialize the module.
+serialized_module = module1.serialize()
+
+# Let's forget about the module for this example.
+del module1
+
+# Deserialize the module.
+module2 = Module.deserialize(serialized_module)
+
+# Instantiate and use it.
+result = module2.instantiate().exports.sum(1, 2)
+
+print(result) # 3
+```
+
+A serialized module is a sequence of bytes. They can be saved in any
+storage.
 
 The `Module.validate` static method check whether the given bytes
 represent valid WebAssembly bytes:

--- a/src/module.rs
+++ b/src/module.rs
@@ -119,13 +119,11 @@ impl Module {
                     runtime_core::load_cache_with(artifact, &runtime::default_compiler())
                 } {
                     Ok(module) => Ok(Py::new(py, Self { module })?),
-
                     Err(_) => Err(RuntimeError::py_err(
                         "Failed to compile the serialized module.",
                     )),
                 }
             }
-
             Err(_) => Err(RuntimeError::py_err("Failed to deserialize the module.")),
         }
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -12,12 +12,12 @@ use pyo3::{
 };
 use std::rc::Rc;
 use wasmer_runtime::{self as runtime, imports, validate, Export};
+use wasmer_runtime_core::{self as runtime_core, cache::Artifact};
 
 #[pyclass]
 /// `Module` is a Python class that represents a WebAssembly module.
 pub struct Module {
     /// The underlying Rust WebAssembly module.
-    #[allow(unused)]
     module: runtime::Module,
 }
 
@@ -29,6 +29,8 @@ impl Module {
     fn new(object: &PyRawObject, bytes: &PyAny) -> PyResult<()> {
         // Read the bytes.
         let bytes = <PyBytes as PyTryFrom>::try_from(bytes)?.as_bytes();
+
+        // Compile the module.
         let module = runtime::compile(bytes).map_err(|error| {
             RuntimeError::py_err(format!("Failed to compile the module:\n    {}", error))
         })?;
@@ -42,6 +44,8 @@ impl Module {
     // Instantiate the module into an `Instance` Python object.
     fn instantiate(&self, py: Python) -> PyResult<Py<Instance>> {
         let imports = imports! {};
+
+        // Instantiate the module.
         let instance = match self.module.instantiate(&imports) {
             Ok(instance) => Rc::new(instance),
             Err(e) => {
@@ -84,6 +88,46 @@ impl Module {
                 memory: Py::new(py, Memory { memory })?,
             },
         )?)
+    }
+
+    /// Serialize the module into Python bytes.
+    fn serialize<'p>(&self, py: Python<'p>) -> PyResult<&'p PyBytes> {
+        // Get the module artifact.
+        match self.module.cache() {
+            // Serialize the artifact.
+            Ok(artifact) => match artifact.serialize() {
+                Ok(serialized_artifact) => Ok(PyBytes::new(py, serialized_artifact.as_slice())),
+                Err(_) => Err(RuntimeError::py_err(
+                    "Failed to serialize the module artifact.",
+                )),
+            },
+            Err(_) => Err(RuntimeError::py_err("Failed to get the module artifact.")),
+        }
+    }
+
+    /// Deserialize Python bytes into a module instance.
+    #[staticmethod]
+    fn deserialize(bytes: &PyAny, py: Python) -> PyResult<Py<Module>> {
+        // Read the bytes.
+        let serialized_module = <PyBytes as PyTryFrom>::try_from(bytes)?.as_bytes();
+
+        // Deserialize the artifact.
+        match Artifact::deserialize(serialized_module) {
+            Ok(artifact) => {
+                // Get the module from the artifact.
+                match unsafe {
+                    runtime_core::load_cache_with(artifact, &runtime::default_compiler())
+                } {
+                    Ok(module) => Ok(Py::new(py, Self { module })?),
+
+                    Err(_) => Err(RuntimeError::py_err(
+                        "Failed to compile the serialized module.",
+                    )),
+                }
+            }
+
+            Err(_) => Err(RuntimeError::py_err("Failed to deserialize the module.")),
+        }
     }
 
     /// Check that given bytes represent a valid WebAssembly module.

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -28,3 +28,13 @@ def test_failed_to_compile():
 
 def test_instantiate():
     assert Module(TEST_BYTES).instantiate().exports.sum(1, 2) == 3
+
+def test_serialize():
+    assert type(Module(TEST_BYTES).serialize()) == bytes
+
+def test_deserialize():
+    serialized_module = Module(TEST_BYTES).serialize()
+    module = Module.deserialize(serialized_module)
+    del serialized_module
+
+    assert module.instantiate().exports.sum(1, 2) == 3


### PR DESCRIPTION
These patches allow to serialize and deserialized a compiled WebAssembly module, thus saving the compilation time for the next use.

Example:

```python
from wasmer import Module

# Get the Wasm bytes.
wasm_bytes = open('my_program.wasm', 'rb').read()

# Compile the bytes into a Wasm module.
module1 = Module(wasm_bytes)

# Serialize the module.
serialized_module = module1.serialize()

# Let's forget about the module for this example.
del module1

# Deserialize the module.
module2 = Module.deserialize(serialized_module)

# Instantiate and use it.
result = module2.instantiate().exports.sum(1, 2)

print(result) # 3
```