### PR TITLE
feat(extension) Add `wasmer.__core_version__`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/wasmerio/python-ext-wasm"
 keywords = ["python", "extension", "webassembly"]
 categories = ["wasm"]
+build = "build.rs"
 
 [lib]
 name = "wasmer"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+fn main() {
+    let command_output = Command::new(env!("CARGO"))
+        .arg("pkgid")
+        .arg("--offline")
+        .arg("--package")
+        .arg("wasmer-runtime-core")
+        .output()
+        .expect("Failed to execute `cargo` to read package ID.")
+        .stdout;
+    let wasmer_runtime_core_pkgid = String::from_utf8_lossy(command_output.as_slice());
+    let separator_index = wasmer_runtime_core_pkgid
+        .rfind(':')
+        .expect("Failed to find the version of `wasmer-runtime-core`.");
+    let wasmer_runtime_core_version = &wasmer_runtime_core_pkgid[separator_index + 1..];
+
+    println!(
+        "cargo:rustc-env=WASMER_RUNTIME_CORE_VERSION={}",
+        wasmer_runtime_core_version
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use value::Value;
 #[pymodule]
 fn wasmer(_py: Python, module: &PyModule) -> PyResult<()> {
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    module.add("__core_version__", env!("WASMER_RUNTIME_CORE_VERSION"))?;
     module.add_class::<Instance>()?;
     module.add_class::<Module>()?;
     module.add_class::<Value>()?;

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -17,6 +17,9 @@ def test_is_a_class():
 def test_version():
     assert isinstance(wasmer.__version__, str)
 
+def test_core_version():
+    assert isinstance(wasmer.__core_version__, str)
+
 def test_can_construct():
     assert isinstance(Instance(TEST_BYTES), Instance)
 


### PR DESCRIPTION
Fix #41.

The `__core_version__` constant is set to the version of the
`wasmer-runtime-core` Rust package, aka the core runtime.

Thoughts @Mec-iS?

To test:

```python
import wasmer

print(wasmer.__core__version__)
```