### PR TITLE
feat(memory) Bound slice to the size of the memory view

### DIFF
--- a/src/memory/view.rs
+++ b/src/memory/view.rs
@@ -6,7 +6,7 @@ use pyo3::{
     prelude::*,
     types::{PyAny, PySlice},
 };
-use std::{mem::size_of, rc::Rc};
+use std::{cmp::min, mem::size_of, rc::Rc};
 use wasmer_runtime::memory::Memory;
 
 macro_rules! memory_view {
@@ -49,7 +49,7 @@ macro_rules! memory_view {
                         )));
                     }
 
-                    (offset + slice.start as usize)..(offset + slice.stop as usize)
+                    (offset + slice.start as usize)..(min(offset + slice.stop as usize, view.len()))
                 } else if let Ok(index) = index.extract::<isize>() {
                     if index < 0 {
                         return Err(IndexError::py_err(


### PR DESCRIPTION
When writing `memory_view[0:]`, an error could be raised because the
default Python bound for a slice with no upper bound is likely to be
larger than the memory size. Instead of getting an error, this patch
bounds the slice upper bound to the memory size.