### PR TITLE
feat(memory) Add the `Memory.grow` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ print(repr(value_i32)) # I32(7)
 A WebAssembly instance has its own memory, represented by the `Memory`
 class. It is accessible by the `Instance.memory` getter.
 
+The `Memory.grow` method allows to grow the memory by a number of
+pages (of 65kb each).
+
+```python
+instance.memory.grow(1)
+```
+
 The `Memory` class offers methods to create views of the memory
 internal buffer, e.g. `uint8_view`, `int8_view`, `uint16_view`
 etc. All these methods accept one argument: `offset`, to subset the

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,8 +1,9 @@
 //! Memory API of an WebAssembly instance.
 
-use pyo3::prelude::*;
+use pyo3::{exceptions::RuntimeError, prelude::*};
 use std::rc::Rc;
 use wasmer_runtime::Memory as WasmMemory;
+use wasmer_runtime_core::units::Pages;
 
 pub mod view;
 
@@ -77,5 +78,12 @@ impl Memory {
                 offset,
             },
         )
+    }
+
+    fn grow(&self, number_of_pages: u32) -> PyResult<u32> {
+        self.memory
+            .grow(Pages(number_of_pages))
+            .map(|previous_pages| previous_pages.0)
+            .map_err(|err| RuntimeError::py_err(format!("Failed to grow the memory: {}.", err)))
     }
 }

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -140,3 +140,28 @@ def test_memory_views_share_the_same_buffer():
     assert int16[0] == 0b00000100_00000001
     assert int16[1] == 0b01000000_00010000
     assert int32[0] == 0b01000000_00010000_00000100_00000001
+
+def test_memory_grow():
+    instance = Instance(TEST_BYTES)
+    memory = instance.memory
+    int8 = memory.int8_view()
+
+    old_memory_length = len(int8)
+
+    assert old_memory_length == 1114112
+
+    memory.grow(1)
+
+    memory_length = len(int8)
+
+    assert memory_length == 1179648
+    assert memory_length - old_memory_length == 65536
+
+def test_memory_grow_too_much():
+    with pytest.raises(RuntimeError) as context_manager:
+        Instance(TEST_BYTES).memory.grow(100000)
+
+    exception = context_manager.value
+    assert str(exception) == (
+        'Failed to grow the memory: Grow Error: Failed to add pages because would exceed maximum number of pages. Left: 17, Right: 100000, Pages added: 100017.'
+    )


### PR DESCRIPTION
This method can be used to grow the memory by a number of pages (65kb each).