### PR TITLE
Make wasmer silently available anywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
             export PATH="/home/circleci/.pyenv/versions/3.7.3/bin/:$PATH"
             source .env/bin/activate
             just build
+            just wasmer_any
 
       # Run the extension test suites.
       - run:
@@ -124,7 +125,8 @@ jobs:
             export PATH="/home/circleci/.pyenv/versions/3.6.8/bin/:$PATH"
             export PATH="/home/circleci/.pyenv/versions/3.5.7/bin/:$PATH"
             source .env/bin/activate
-            pyo3-pack publish -i python3.7 python3.6 python3.5 -u wasmer
+            just wasmer_any
+            just publish
 
 
 # List of workflows.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /benchmarks/__pycache__/
 /target
 /tests/__pycache__/
+/wasmer-any/dist
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,19 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nix"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1074,13 +1062,13 @@ name = "wasmer"
 version = "0.3.0"
 dependencies = [
  "pyo3 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-clif-backend"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1089,7 +1077,7 @@ dependencies = [
  "cranelift-native 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-bench 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1098,8 +1086,8 @@ dependencies = [
  "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-fork-frontend 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-fork-wasm 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-win-exception-handler 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-win-exception-handler 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.32.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1130,18 +1118,18 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-backend 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-clif-backend 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-runtime-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1155,7 +1143,7 @@ dependencies = [
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1170,14 +1158,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-win-exception-handler"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1317,8 +1305,7 @@ dependencies = [
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
-"checksum nix 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "319fffb13b63c0f4ff5a4e1c97566e7e741561ff5d03bf8bbf11653454bbd70b"
-"checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
+"checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
@@ -1384,12 +1371,12 @@ dependencies = [
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wasmer-clif-backend 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c9d23d87d8b9d2548d787b808b99c10cff1b210d82d8a7b081a3a339e63d3fe1"
+"checksum wasmer-clif-backend 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "96ab6e1df489016effe38c56f40ac7d4f716f4d178ec40906f6a0ed31c6bd333"
 "checksum wasmer-clif-fork-frontend 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "620fd484c3348e4bb565d861cddb0c05170337aaa152b6ba61620d054ab17cd9"
 "checksum wasmer-clif-fork-wasm 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5e42fa4281de137d5a23b8197d29c218212077c6d55d0dfed7bb80c76308ba4"
-"checksum wasmer-runtime 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc14bdc1eeecf2ec7df393af1830c82d51e178d450fa0320e45a8f01980548c"
-"checksum wasmer-runtime-core 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff7eec0a09a115ccb0c50b726b319f7e3193bd870f82849ee9e81968a10d2392"
-"checksum wasmer-win-exception-handler 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "afe92ce57a2f7e6694804719441fe77b3a9217897d3ece4eaec16c2acb4e45cd"
+"checksum wasmer-runtime 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fdfe76f254bc9dcf47dd84e2cbb0adddb98f198c86e52ae57752da954b4f770d"
+"checksum wasmer-runtime-core 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c9d4b2d56a72281b3c385ce0850b3c2b7071b34f6148c4077ba1b93f185197c5"
+"checksum wasmer-win-exception-handler 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "caa30b1b3ed7cd3fc8ecb291188387b1e852508f4d35acb523cab323b1dd9c84"
 "checksum wasmparser 0.32.1 (registry+https://github.com/rust-lang/crates.io-index)" = "22d1801de30f112ddaf665291097694ee33a36d1cb414b53a921d05b3519674a"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmer"
 version = "0.3.0"
-authors = ["Ivan Enderlin <ivan.enderlin@hoa-project.net>"]
+authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2018"
 description = "Python extension to run WebAssembly binaries"
 readme = "README.md"
@@ -15,8 +15,8 @@ name = "wasmer"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmer-runtime = "0.5.5"
-wasmer-runtime-core = "0.5.5"
+wasmer-runtime = "0.5.6"
+wasmer-runtime-core = "0.5.6"
 pyo3 = { version = "0.7.0", features = ["extension-module"] }
 
 [package.metadata.pyo3-pack]

--- a/justfile
+++ b/justfile
@@ -37,6 +37,15 @@ benchmark:
 inspect:
 	@python -c "help('wasmer')"
 
+# Create a distribution of wasmer that can be installed
+# anywhere (it will fail on import)
+wasmer_any:
+	mkdir -p ./target/wheels/
+	cd wasmer-any && pip3 wheel . -w ../target/wheels/
+
+publish:
+	pyo3-pack publish -i python3.7 python3.6 python3.5 -u wasmer
+
 # Local Variables:
 # mode: makefile
 # End:

--- a/wasmer-any/setup.py
+++ b/wasmer-any/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup
+from setuptools.dist import Distribution
+
+# with open('../README.md', 'rb') as f:
+#     readme = f.read().decode('utf-8')
+
+setup(
+    name='wasmer',
+    version='0.3.0',
+    author='The Wasmer Engineering Team',
+    author_email='engineering@wasmer.io',
+    license='MIT',
+    packages=['wasmer'],
+    description='Python extension to run WebAssembly binaries',
+    # long_description=readme,
+    # long_description_content_type='text/markdown',
+    zip_safe=False,
+    platforms='any',
+    classifiers=[
+        "Programming Language :: Python",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/wasmer-any/wasmer/__init__.py
+++ b/wasmer-any/wasmer/__init__.py
@@ -1,0 +1,1 @@
+raise ImportError("Wasmer is not available on this system")


### PR DESCRIPTION
## Problem

Python wasmer installation is failing in various systems (mainly because of alpine linux).
https://github.com/syrusakbary/snapshottest/issues/88
https://github.com/syrusakbary/fastdiff/issues/2
https://github.com/syrusakbary/fastdiff/issues/3

One way to make it work very easily is by creating a generic wheel that it's always available but that fails on import (rather than on install).

This PR adds that, and upgrades wasmer to `0.5.6` as well