### PR TITLE
feat(memory) Memory views support slice assignment

### DIFF
--- a/benchmarks/test_memory_view_set.py
+++ b/benchmarks/test_memory_view_set.py
@@ -1,0 +1,25 @@
+import os
+import wasmer
+
+here = os.path.dirname(os.path.realpath(__file__))
+TEST_BYTES = open(here + '/../tests/tests.wasm', 'rb').read()
+
+N = 5000
+
+def test_benchmark_memory_view_set_sequence_with_slice_assignment(benchmark):
+    memory = wasmer.Instance(TEST_BYTES).memory.uint8_view()
+
+    def bench():
+        memory[0:255] = range(0, 255)
+
+    benchmark(bench)
+
+
+def test_benchmark_memory_view_set_sequence_with_a_loop(benchmark):
+    memory = wasmer.Instance(TEST_BYTES).memory.uint8_view()
+
+    def bench():
+        for nth in range(0, 255):
+            memory[nth] = nth
+
+    benchmark(bench)

--- a/benchmarks/test_nbody.py
+++ b/benchmarks/test_nbody.py
@@ -1,9 +1,6 @@
 from math import sqrt
 from ppci import wasm
-import inspect
 import os
-import pytest
-import sys
 import wasmer
 
 here = os.path.dirname(os.path.realpath(__file__))

--- a/examples/greet.py
+++ b/examples/greet.py
@@ -9,19 +9,15 @@ instance = Instance(wasm_bytes)
 
 # Set the subject to greet.
 subject = bytes('Wasmer 🐍', 'utf-8')
-length_of_subject = len(subject)
+length_of_subject = len(subject) + 1
 
 # Allocate memory for the subject, and get a pointer to it.
 input_pointer = instance.exports.allocate(length_of_subject)
 
 # Write the subject into the memory.
 memory = instance.memory.uint8_view(input_pointer)
-
-for nth in range(0, length_of_subject):
-    memory[nth] = subject[nth]
-
-# C-string terminates by NULL.
-memory[length_of_subject] = 0
+memory[0:length_of_subject] = subject
+memory[length_of_subject] = 0 # C-string terminates by NULL.
 
 # Run the `greet` function. Give the pointer to the subject.
 output_pointer = instance.exports.greet(input_pointer)

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ python-run file='':
 
 # Run the tests.
 test:
-	@py.test tests
+	@py.test -v tests
 
 # Run the benchmarks.
 benchmark:

--- a/justfile
+++ b/justfile
@@ -29,9 +29,9 @@ python-run file='':
 test:
 	@py.test -v tests
 
-# Run the benchmarks.
-benchmark:
-	@py.test benchmarks
+# Run one or more benchmarks.
+benchmark benchmark-filename='':
+	@py.test benchmarks/{{benchmark-filename}}
 
 # Inspect the `python-ext-wasm` extension.
 inspect:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -99,6 +99,37 @@ def test_get_invalid_index():
         'Only integers and slices are valid to represent an index.'
     )
 
+def test_set_single_value():
+    memory = Instance(TEST_BYTES).memory.uint8_view()
+
+    assert memory[7] == 0
+    memory[7] = 42
+    assert memory[7] == 42
+
+def test_set_list():
+    memory = Instance(TEST_BYTES).memory.uint8_view()
+
+    memory[7:12] = [1, 2, 3, 4, 5]
+    assert memory[7:12] == [1, 2, 3, 4, 5]
+
+def test_set_bytes():
+    memory = Instance(TEST_BYTES).memory.uint8_view()
+
+    memory[7:12] = bytes(b'abcde')
+    assert memory[7:12] == [97, 98, 99, 100, 101]
+
+def test_set_bytearray():
+    memory = Instance(TEST_BYTES).memory.uint8_view()
+
+    memory[7:12] = bytearray(b'abcde')
+    assert memory[7:12] == [97, 98, 99, 100, 101]
+
+def test_set_values_with_slice_and_step():
+    memory = Instance(TEST_BYTES).memory.uint8_view()
+
+    memory[7:12:2] = [1, 2, 3, 4, 5]
+    assert memory[7:12] == [1, 0, 2, 0, 3]
+    
 def test_set_out_of_range():
     with pytest.raises(IndexError) as context_manager:
         memory = Instance(TEST_BYTES).memory.uint8_view()


### PR DESCRIPTION
When writing `view = memory.uint8_view()` for instance, it is now
possible to set a sequence directly by writing:

```python
view[start:stop:step] = sequence
```

instead of writing a loop like:

```python
for nth in range(0, length):
    view[nth] = sequence[nth]
```

First, `__setitem__` takes 2 forms of inputs: Either the key and value
are both integers, or they are respectively a slice and a sequence. By
“sequence”, we mean the [object protocol
sequence](docs.python.org/3/c-api/sequence.html), so it
includes list, bytes, bytearray etc.

Second, let's focus on the new feature where key and value are a slice
and a sequence:

- The sequence item type must be down-castable to the memory item
  type, e.g.  if it is a `uint8` view, then the item must be
  down-castable to `u8`, and so on.

- The slice is bound to the memory view length, so that it's
  impossible to write out-of-memory.

- The slice accepts start, stop, and step parameters. So it is
  possible to write `view[0:5:2]` for instance, and it will write at
  positions 0, 2, 4. Stop must be greater than start. Step must be
  positive.

- There is a huge difference with list slice assignment: Elements in
  memory cannot be moved, so the assignment only overwrite
  elements. For instance, with a regular list:

  ```python
  a = [1, 2, 3, 4, 5]
  a[1:3] = [10, 11, 12]

  assert a == [1, 10, 11, 12, 4, 5]
  ```

  In the example above, the list `[10, 11, 12]` replaces the slice
  `1:3`, so it replaces the elements `[2, 3]` by `[10, 11, 12]`

  With memory view, we can't move elements (no inserts, no
  deletions). It overwrites them, e.g.:

  ```python
  view[0:5] = [1, 2, 3, 4, 5]
  view[1:3] = [10, 11, 12]

  assert view[0:5] == [1, 10, 11, 4, 5]
  ```

  What happens here?

  - The slice and the sequence iterators are zipped together. As soon
    as one iterator finishes, `__setitem__` stops writing into the
    memory view. In the example above, the slice iterator is shorter
    than the sequence iterator (the length of the slice iterator is 2,
    while the length of the sequence iterator is 3, so only 2 elements
    will be written).

  - So 2 elements are picked from the sequence, i.e. `[10, 11]`. They
    are written in positions given by the slice, here `1` and `2`. The
    memory then looks like `[1, 10, 11, 4, 5]`.

  Another example with a step > 1 in the slice:

  ```python
  view[0:5] = [1, 2, 3, 4, 5]
  view[1:5:2] = [10, 11, 12]

  assert view[0:5] == [1, 10, 3, 11, 5]
  ```

  What happens here?

  - The length of the slice iterator is 2, so the first two elements
    of the sequence will be picked, i.e. `[10, 11]`.

  - The positions given by the slice are `1` and `3`. The memory then
    looks like `[1, 10, 3, 11, 5]`. Positions `0`, `2` and `4` are
    unmodified.

Benchmarks show an improvement of a factor 10,
i.e. it is 10 times faster to use slice assignment than a loop
assignment. Results of `just benchmark test_memory_view_set.py`:


Name (time in us) |                                                    Min  |               Max   |            Mean    |         StdDev        |     Median       |        IQR |           Outliers | OPS (Kops/s)|            Rounds | Iterations
|-|-|-|-|-|-|-|-|-|-|-|
…_with_slice_assignment  |    6.8870 (1.0) |      73.8030 (1.0)    |   7.5302 (1.0)    |   1.8991 (1.0)   |    7.2790 (1.0)     | 0.2390 (1.0)  |    477;3204 |     132.7992 (1.0)   |    24459   |        1
…_with_a_loop   |            68.1770 (9.90) |    412.7400 (5.59)   |  73.6944 (9.79)|     10.1384 (5.34)   |  71.7810 (9.86)     2.7390 (11.46) |   601;1050   |    13.5696 (0.10)  |    13048     |      1

