### PR TITLE
Add trait to  allow inspection of exported functions

### DIFF
--- a/src/instance/inspect.rs
+++ b/src/instance/inspect.rs
@@ -1,0 +1,21 @@
+use pyo3::prelude::*;
+
+use wasmer_runtime_core::instance::DynFunc;
+
+pub trait InspectExported {
+    // A convenience method to move Wasmer runtime's dynamic function object
+    // into scope for pyo3 constructors/callers
+    fn move_runtime_func_obj(&self) -> Result<DynFunc, PyErr>;
+
+    // Convenience functions to allow inspection of the exported function.
+    // NOTE: Python provides the `inspect` module for this. Future improvements
+    // can be made on this side to have a Trait for these functions, as developers
+    // may need an interface to the underlying `Instance::dyn_func`.
+
+    // return the signature of an exported function
+    fn signature(&self) -> String;
+
+    // return the parameters of an exporterd function
+    fn params(&self) -> String;
+
+}

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -1,0 +1,119 @@
+//! The `wasmer.Instance` Python object to build WebAssembly instances.
+//!
+//! The `Instance` class has the following declaration:
+//!
+//! * The constructor reads bytes from its first parameter, and it
+//!   expects those bytes to represent a valid WebAssembly module,
+//! * The `exports` getter, to get exported functions from the
+//!   WebAssembly module, e.g. `instance.exports.sum(1, 2)` to call the
+//!   exported function `sum` with arguments `1` and `2`,
+//! * The `memory` getter, to get the exported memory (if any) from
+//!   the WebAssembly module, .e.g. `instance.memory.uint8_view()`, see
+//!   the `wasmer.Memory` class.
+pub (crate) mod exported;
+pub (crate) mod inspect;
+
+use crate::{
+    memory::Memory,
+    instance::exported::ExportedFunctions
+};
+use pyo3::{
+    exceptions::RuntimeError,
+    prelude::*,
+    types::{PyAny, PyBytes},
+    PyNativeType, PyTryFrom
+};
+use std::rc::Rc;
+use wasmer_runtime::{imports, instantiate, Export};
+
+#[pyclass]
+/// `Instance` is a Python class that represents a WebAssembly instance.
+///
+/// # Examples
+///
+/// ```python
+/// from wasmer import Instance
+///
+/// instance = Instance(wasm_bytes)
+/// ```
+pub struct Instance {
+    /// All WebAssembly exported functions represented by an
+    /// `ExportedFunctions` object.
+    pub(crate) exports: Py<ExportedFunctions>,
+
+    /// The WebAssembly exported memory represented by a `Memory`
+    /// object.
+    pub(crate) memory: Py<Memory>,
+}
+
+#[pymethods]
+/// Implement methods on the `Instance` Python class.
+impl Instance {
+    #[new]
+    /// The constructor instantiates a new WebAssembly instance basde
+    /// on WebAssembly bytes (represented by the Python bytes type).
+    fn new(object: &PyRawObject, bytes: &PyAny) -> PyResult<()> {
+        // Read the bytes.
+        let bytes = <PyBytes as PyTryFrom>::try_from(bytes)?.as_bytes();
+
+        // Instantiate the WebAssembly module.
+        let imports = imports! {};
+        let instance = match instantiate(bytes, &imports) {
+            Ok(instance) => Rc::new(instance),
+            Err(e) => {
+                return Err(RuntimeError::py_err(format!(
+                    "Failed to instantiate the module:\n    {}",
+                    e
+                )))
+            }
+        };
+
+        let py = object.py();
+
+        // Collect the exported functions from the WebAssembly module.
+        let mut exported_functions = Vec::new();
+
+        for (export_name, export) in instance.exports() {
+            if let Export::Function { .. } = export {
+                exported_functions.push(export_name);
+            }
+        }
+
+        // Collect the exported memory from the WebAssembly module.
+        let memory = instance
+            .exports()
+            .find_map(|(_, export)| match export {
+                Export::Memory(memory) => Some(Rc::new(memory)),
+                _ => None,
+            })
+            .ok_or_else(|| RuntimeError::py_err("No memory exported."))?;
+
+        // Instantiate the `Instance` Python class.
+        object.init({
+            Self {
+                exports: Py::new(
+                    py,
+                    ExportedFunctions {
+                        instance: instance.clone(),
+                        functions: exported_functions,
+                    },
+                )?,
+                memory: Py::new(py, Memory { memory })?,
+            }
+        });
+
+        Ok(())
+    }
+
+    #[getter]
+    /// The `exports` getter.
+    fn exports(&self) -> PyResult<&Py<ExportedFunctions>> {
+        Ok(&self.exports)
+    }
+
+    #[getter]
+    /// The `memory` getter.
+    fn memory(&self) -> PyResult<&Py<Memory>> {
+        Ok(&self.memory)
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,7 +1,8 @@
 //! The `wasmer.Module` Python object to build WebAssembly modules.
 
 use crate::{
-    instance::{ExportedFunctions, Instance},
+    instance::Instance,
+    instance::exported::ExportedFunctions,
     memory::Memory,
 };
 use pyo3::{

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -73,3 +73,11 @@ def test_call_void():
 
 def test_memory_view():
     assert isinstance(Instance(TEST_BYTES).memory.uint8_view(), Uint8Array)
+
+def test_getfullargspec():
+    i = Instance(TEST_BYTES)
+    assert isinstance(i.exports.sum.getfullargspec, str)
+
+def test_getargs():
+    i = Instance(TEST_BYTES)
+    assert isinstance(i.exports.sum.getargs, str)


### PR DESCRIPTION
* `InspectExported`: add methods to retrieve signature of `DynFunc`
* Create a `instance` module
* Factorize out `ExportedFunction`

NOTE: substitute #69 

I found these methods very useful when trying to implement [these utilities](https://github.com/Mec-iS/rust-wasm-python-101/blob/50ae7799bb0eeb725a5792dd1e83d258b70e21ae/pywasm/src/utils.py#L9) for leveraging memory views from Python.