### PR TITLE
feat(module) Implement the `exports` getter to list exports

### DIFF
--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -113,10 +113,7 @@ impl Instance {
 
     #[getter]
     /// The `memory` getter.
-    fn memory(&self) -> PyResult<PyObject> {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
+    fn memory(&self, py: Python) -> PyResult<PyObject> {
         match &self.memory {
             Some(memory) => Ok(memory.into_py(py)),
             None => Ok(py.None()),

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -29,6 +29,62 @@ def test_failed_to_compile():
 def test_instantiate():
     assert Module(TEST_BYTES).instantiate().exports.sum(1, 2) == 3
 
+def test_exports():
+    assert Module(TEST_BYTES).exports == [
+        {
+            "name": "memory",
+            "kind": "memory",
+        },
+        {
+            "name": "__heap_base",
+            "kind": "global",
+        },
+        {
+            "name": "__data_end",
+            "kind": "global",
+        },
+        {
+            "name": "sum",
+            "kind": "function",
+        },
+        {
+            "name": "arity_0",
+            "kind": "function",
+        },
+        {
+            "name": "i32_i32",
+            "kind": "function",
+        },
+        {
+            "name": "i64_i64",
+            "kind": "function",
+        },
+        {
+            "name": "f32_f32",
+            "kind": "function",
+        },
+        {
+            "name": "f64_f64",
+            "kind": "function",
+        },
+        {
+            "name": "i32_i64_f32_f64_f64",
+            "kind": "function",
+        },
+        {
+            "name": "bool_casted_to_i32",
+            "kind": "function",
+        },
+        {
+            "name": "string",
+            "kind": "function",
+        },
+        {
+            "name": "void",
+            "kind": "function",
+        },
+    ]
+
 def test_serialize():
     assert type(Module(TEST_BYTES).serialize()) == bytes
 


### PR DESCRIPTION
This patch implements `Module.exports` to list all the exports with the associated name and kind.