### PR TITLE
feat(memory) New `Buffer` class, to read memory fast

### DIFF
--- a/benchmarks/test_memory_view_get.py
+++ b/benchmarks/test_memory_view_get.py
@@ -4,8 +4,6 @@ import wasmer
 here = os.path.dirname(os.path.realpath(__file__))
 TEST_BYTES = open(here + '/../tests/tests.wasm', 'rb').read()
 
-N = 5000
-
 def test_benchmark_memory_view_int8_get(benchmark):
     memory = wasmer.Instance(TEST_BYTES).memory.uint8_view()
 

--- a/benchmarks/test_memory_view_get.py
+++ b/benchmarks/test_memory_view_get.py
@@ -1,0 +1,31 @@
+import os
+import wasmer
+
+here = os.path.dirname(os.path.realpath(__file__))
+TEST_BYTES = open(here + '/../tests/tests.wasm', 'rb').read()
+
+N = 5000
+
+def test_benchmark_memory_view_int8_get(benchmark):
+    memory = wasmer.Instance(TEST_BYTES).memory.uint8_view()
+
+    def bench():
+        _ = memory[0:255]
+
+    benchmark(bench)
+
+def test_benchmark_memory_view_memoryview_get(benchmark):
+    memory = memoryview(wasmer.Instance(TEST_BYTES).memory.buffer)
+
+    def bench():
+        _ = memory[0:255]
+
+    benchmark(bench)
+
+def test_benchmark_memory_view_bytearray_get(benchmark):
+    memory = bytearray(wasmer.Instance(TEST_BYTES).memory.buffer)
+
+    def bench():
+        _ = memory[0:255]
+
+    benchmark(bench)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ fn wasmer(py: Python, module: &PyModule) -> PyResult<()> {
     module.add_class::<memory::view::Uint16Array>()?;
     module.add_class::<memory::view::Uint32Array>()?;
     module.add_class::<memory::view::Uint8Array>()?;
+    module.add_class::<memory::buffer::Buffer>()?;
 
     {
         let enum_module = py.import("enum")?;

--- a/src/memory/buffer.rs
+++ b/src/memory/buffer.rs
@@ -1,4 +1,4 @@
-//! The `Buffer` Python objects to represent a WebAssembly memory
+//! The `Buffer` Python object to represent a WebAssembly memory
 //! through the Python Buffer Protocol.
 
 use pyo3::{
@@ -71,7 +71,7 @@ impl PyBufferProtocol for Buffer {
 
             // An indicator of whether the buffer is read-only. This
             // field is controlled by the `PyBUF_WRITABLE` flag.
-            (*view).readonly = if dbg!(PyBUF_WRITABLE == (flags & PyBUF_WRITABLE)) {
+            (*view).readonly = if PyBUF_WRITABLE == (flags & PyBUF_WRITABLE) {
                 0
             } else {
                 1

--- a/src/memory/buffer.rs
+++ b/src/memory/buffer.rs
@@ -1,0 +1,189 @@
+//! The `Buffer` Python objects to represent a WebAssembly memory
+//! through the Python Buffer Protocol.
+
+use pyo3::{
+    class::buffer::PyBufferProtocol,
+    exceptions::BufferError,
+    ffi::{PyBUF_FORMAT, PyBUF_ND, PyBUF_STRIDES, PyBUF_WRITABLE, Py_buffer},
+    prelude::*,
+};
+use std::{
+    ffi::{c_void, CStr},
+    mem,
+    ops::Deref,
+    os::raw::{c_char, c_int},
+    ptr,
+    rc::Rc,
+};
+use wasmer_runtime::memory::Memory;
+
+#[pyclass]
+pub struct Buffer {
+    pub memory: Rc<Memory>,
+}
+
+#[pyproto]
+impl PyBufferProtocol for Buffer {
+    fn bf_getbuffer(&self, view: *mut Py_buffer, flags: c_int) -> PyResult<()> {
+        if view.is_null() {
+            return Err(BufferError::py_err(
+                "`Py_buffer` cannot be filled because it is null.",
+            ));
+        }
+
+        let memory_view = self.memory.view::<u8>();
+
+        // Fill `Py_buffer` according to https://docs.python.org/3/c-api/buffer.html.
+        unsafe {
+            // A pointer to the start of the logical structure
+            // described by the buffer fields. This can be any
+            // location within the underlying physical memory block of
+            // the exporter. For example, with negative strides the
+            // value may point to the end of the memory block.
+            //
+            // For contiguous arrays, the value points to the
+            // beginning of the memory block.
+            (*view).buf = memory_view.deref().as_ptr() as *mut c_void;
+
+            // A new reference to the exporting object. The reference
+            // is owned by the consumer and automatically decremented
+            // and set to `NULL` by `PyBuffer_Release()`. The field is the
+            // equivalent of the return value of any standard C-API
+            // function.
+            //
+            // As a special case, for temporary buffers that are
+            // wrapped by `PyMemoryView_FromBuffer()` or
+            // `PyBuffer_FillInfo()` this field is `NULL`. In general,
+            // exporting objects MUST NOT use this scheme.
+            (*view).obj = ptr::null_mut();
+
+            // `product(shape) * itemsize`. For contiguous arrays,
+            // this is the length of the underlying memory block. For
+            // non-contiguous arrays, it is the length that the
+            // logical structure would have if it were copied to a
+            // contiguous representation.
+            //
+            // Accessing `((char *)buf)[0]` up to `((char *)buf)[len-1]`
+            // is only valid if the buffer has been obtained by a
+            // request that guarantees contiguity. In most cases such
+            // a request will be `PyBUF_SIMPLE` or `PyBUF_WRITABLE`.
+            (*view).len = memory_view.len() as isize;
+
+            // An indicator of whether the buffer is read-only. This
+            // field is controlled by the `PyBUF_WRITABLE` flag.
+            (*view).readonly = if dbg!(PyBUF_WRITABLE == (flags & PyBUF_WRITABLE)) {
+                0
+            } else {
+                1
+            };
+
+            // Item size in bytes of a single element. Same as the
+            // value of `struct.calcsize()` called on non-`NULL`
+            // format values.
+            //
+            // Important exception: If a consumer requests a buffer
+            // without the `PyBUF_FORMAT` flag, format will be set to
+            // `NULL`, but `itemsize` still has the value for the
+            // original format.
+            //
+            // If `shape` is present, the equality `product(shape) *
+            // itemsize == len` still holds and the consumer can use
+            // `itemsize` to navigate the buffer.
+            //
+            // If `shape` is `NULL` as a result of a `PyBUF_SIMPLE` or
+            // a `PyBUF_WRITABLE` request, the consumer must disregard
+            // `itemsize` and assume `itemsize == 1`.
+            (*view).itemsize = mem::size_of::<u8>() as isize;
+
+            // A `NUL` terminated string in `struct` module style
+            // syntax describing the contents of a single item. If
+            // this is `NULL`, `"B"` (unsigned bytes) is assumed.
+            //
+            // This field is controlled by the `PyBUF_FORMAT` flag.
+            (*view).format = if PyBUF_FORMAT == (flags & PyBUF_FORMAT) {
+                let format = CStr::from_bytes_with_nul(b"B\0")
+                    .expect("The format must be a valid `NUL` terminated string.");
+
+                format.as_ptr() as *mut c_char
+            } else {
+                ptr::null_mut()
+            };
+
+            // The number of dimensions the memory represents as an
+            // n-dimensional array. If it is `0`, `buf` points to a
+            // single item representing a scalar. In this case,
+            // `shape`, `strides` and `suboffsets` MUST be `NULL`.
+            //
+            // The macro `PyBUF_MAX_NDIM` limits the maximum number of
+            // dimensions to 64. Exporters MUST respect this limit,
+            // consumers of multi-dimensional buffers SHOULD be able
+            // to handle up to `PyBUF_MAX_NDIM` dimensions.
+            (*view).ndim = 1;
+
+            // An array of `Py_ssize_t` of length `ndim` indicating
+            // the shape of the memory as an n-dimensional array. Note
+            // that `shape[0] * ... * shape[ndim-1] * itemsize` MUST
+            // be equal to `len`.
+            //
+            // Shape values are restricted to `shape[n] >= 0`. The
+            // case `shape[n] == 0` requires special attention. See
+            // complex arrays for further information.
+            //
+            // The shape array is read-only for the consumer.
+            (*view).shape = if PyBUF_ND == (flags & PyBUF_ND) {
+                &((*view).len) as *const isize as *mut isize
+            } else {
+                ptr::null_mut()
+            };
+
+            // An array of `Py_ssize_t` of length `ndim` giving the
+            // number of bytes to skip to get to a new element in each
+            // dimension.
+            //
+            // Stride values can be any integer. For regular arrays,
+            // strides are usually positive, but a consumer MUST be
+            // able to handle the case `strides[n] <= 0`. See complex
+            // arrays for further information.
+            //
+            // The stride array is read-only for the consumer.
+            (*view).strides = if PyBUF_STRIDES == (flags & PyBUF_STRIDES) {
+                &((*view).itemsize) as *const isize as *mut isize
+            } else {
+                ptr::null_mut()
+            };
+
+            // An array of `Py_ssize_t` of length `ndim`. If
+            // `suboffsets[n] >= 0`, the values stored along the nth
+            // dimension are pointers and the suboffset value dictates
+            // how many bytes to add to each pointer after
+            // de-referencing. A suboffset value that is negative
+            // indicates that no de-referencing should occur (striding
+            // in a contiguous memory block).
+            //
+            // If all suboffsets are negative (i.e. no de-referencing
+            // is needed), then this field must be `NULL` (the default
+            // value).
+            //
+            // This type of array representation is used by the Python
+            // Imaging Library (PIL). See complex arrays for further
+            // information how to access elements of such an array.
+            //
+            // The suboffsets array is read-only for the consumer.
+            (*view).suboffsets = ptr::null_mut();
+
+            // This is for use internally by the exporting object. For
+            // example, this might be re-cast as an integer by the
+            // exporter and used to store flags about whether or not
+            // the shape, strides, and suboffsets arrays must be freed
+            // when the buffer is released. The consumer MUST NOT
+            // alter this value.
+            (*view).internal = ptr::null_mut();
+        }
+
+        Ok(())
+    }
+
+    fn bf_releasebuffer(&self, _view: *mut Py_buffer) -> PyResult<()> {
+        Ok(())
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use wasmer_runtime::Memory as WasmMemory;
 use wasmer_runtime_core::units::Pages;
 
+pub mod buffer;
 pub mod view;
 
 #[pyclass]
@@ -14,6 +15,16 @@ pub struct Memory {
 
 #[pymethods]
 impl Memory {
+    #[getter]
+    fn buffer(&self, py: Python) -> PyResult<Py<buffer::Buffer>> {
+        Py::new(
+            py,
+            buffer::Buffer {
+                memory: self.memory.clone(),
+            },
+        )
+    }
+
     #[args(offset = 0)]
     fn uint8_view(&self, py: Python, offset: usize) -> PyResult<Py<view::Uint8Array>> {
         Py::new(

--- a/src/memory/view.rs
+++ b/src/memory/view.rs
@@ -1,4 +1,4 @@
-//! The `Buffer` Python object to build WebAssembly values.
+//! The `*Array` Python objects to represent WebAsembly memory views.
 
 use pyo3::{
     class::PyMappingProtocol,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -237,8 +237,15 @@ def test_memory_buffer_bytearray():
     int8[0] = 1
     int8[1] = 2
     int8[2] = 3
+    int8[3] = 0x57
+    int8[4] = 0x61
+    int8[5] = 0x73
+    int8[6] = 0x6d
+    int8[7] = 0x65
+    int8[8] = 0x72
 
     byte_array = bytearray(memory.buffer)
 
     assert len(byte_array) == 1114112
     assert byte_array[0:3] == b'\x01\x02\x03'
+    assert byte_array[3:9].decode() == 'Wasmer'

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,4 +1,4 @@
-from wasmer import Instance, Memory, Uint8Array, Int8Array, Uint16Array, Int16Array, Uint32Array, Int32Array
+from wasmer import Instance, Memory, Uint8Array, Int8Array, Uint16Array, Int16Array, Uint32Array, Int32Array, Buffer
 import inspect
 import os
 import pytest
@@ -202,3 +202,43 @@ def test_memory_is_absent():
     instance = Instance(bytes)
 
     assert instance.memory == None
+
+def test_memory_buffer():
+    memory = Instance(TEST_BYTES).memory.buffer
+    assert isinstance(memory, Buffer)
+
+def test_memory_buffer_memoryview():
+    memory = Instance(TEST_BYTES).memory
+
+    int8 = memory.int8_view()
+    int8[0] = 1
+    int8[1] = 2
+    int8[2] = 3
+
+    memory_view = memoryview(memory.buffer)
+
+    assert memory_view.nbytes == 1114112
+    assert memory_view.readonly == True
+    assert memory_view.format == 'B'
+    assert memory_view.itemsize == 1
+    assert memory_view.ndim == 1
+    assert memory_view.shape == (1114112,)
+    assert memory_view.strides == (1,)
+    assert memory_view.suboffsets == ()
+    assert memory_view.c_contiguous == True
+    assert memory_view.f_contiguous == True
+    assert memory_view.contiguous == True
+    assert memory_view[0:3].tolist() == [1, 2, 3]
+
+def test_memory_buffer_bytearray():
+    memory = Instance(TEST_BYTES).memory
+
+    int8 = memory.int8_view()
+    int8[0] = 1
+    int8[1] = 2
+    int8[2] = 3
+
+    byte_array = bytearray(memory.buffer)
+
+    assert len(byte_array) == 1114112
+    assert byte_array[0:3] == b'\x01\x02\x03'


### PR DESCRIPTION
This PR implements the new `Buffer` class. To get one, use the `instance.memory.buffer` getter. This class implements the Python Buffer Protocol. The goal was to test wheter reading operations could be faster, and it actually is, see the benchmark below.

`bytearray(instance.memory.buffer)` is 15x faster than `instance.memory.int8_view()`
`memoryview(instance.memory.buffer)` is 14x faster than `instance.memory.int8_view()`

|Name (time in ns) |                                  Min         |          Max       |          Mean       |        StdDev     |          Median        |       IQR     |      Outliers |OPS (Kops/s) |          Rounds |Iterations|
|------------------------------------------|---------------------:|----------------------:|-------------------:|--------------------:|--------------------:|----------------:|-----------:|-------------------:|---------:|--------:|
|test_benchmark_memory_view_bytearray_get  |     206.5000 (1.0)  |    4,671.5000 (1.0)    |   233.6652 (1.0)   |     72.1470 (1.0)   |    218.1667 (1.0)   |  13.6250 (2.00) | 1864;35841 |  4,279.6266 (1.0)  |   193125  |       24|
|test_benchmark_memory_view_memoryview_get |     223.3000 (1.08) |    6,781.1000 (1.45)   |   237.2921 (1.02)  |     84.0743 (1.17)  |    233.0000 (1.07)  |   6.8000 (1.0)  |    357;797 |  4,214.2158 (0.98) |    78685  |       10|
|test_benchmark_memory_view_int8_get       |   3,269.0000 (15.83)|   66,049.0000 (14.14)  | 3,513.3337 (15.04) |  1,204.6799 (16.70) |  3,444.0000 (15.79) |  84.0000 (12.35)|    237;845 |    284.6299 (0.07) |    48862  |        1|

One question remains open though. Whilst `memoryview` is immutable, `bytearray` is designed to be mutable, but it does mutate the data. It's a room for improvement for a next PR ;-).