### PR TITLE
fix(github-actions) Fix the `release` script since version numbers have changed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,5 +74,4 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           if test -d .env/bin/; then source .env/bin/activate; else source .env/Scripts/activate; fi
           just build-any
-          version=${{ matrix.python }}
-          just publish python${version%.*}
+          just publish python${{ matrix.python }}


### PR DESCRIPTION
Initially, we stripped the `z` in `x.y.z` in version numbers. Now,
they are represented as `x.y` only, so stripping is no longer
required.