### PR TITLE
feat(instance) `ExportedFunction.getfullargspec` returns a `FullArgSpec` named tuple

### DIFF
--- a/src/instance/exports.rs
+++ b/src/instance/exports.rs
@@ -46,6 +46,17 @@ impl From<&ExportImportKind> for &'static str {
     }
 }
 
+impl ToPyObject for ExportImportKind {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            ExportImportKind::Function => (ExportImportKind::Function as u8).into_py(py),
+            ExportImportKind::Memory => (ExportImportKind::Memory as u8).into_py(py),
+            ExportImportKind::Global => (ExportImportKind::Global as u8).into_py(py),
+            ExportImportKind::Table => (ExportImportKind::Table as u8).into_py(py),
+        }
+    }
+}
+
 #[pyclass]
 /// `ExportedFunction` is a Python class that represents a WebAssembly
 /// exported function. Such a function can be invoked from Python by using the

--- a/src/instance/exports.rs
+++ b/src/instance/exports.rs
@@ -1,18 +1,17 @@
 //! The `ExportedFunction` and relative collection that encapsulate Wasmer
 //!  memory and instances.
 
-use super::inspect::InspectExportedFunction;
-use crate::value::Value;
+use crate::{instance::inspect::InspectExportedFunction, r#type::Type, value::Value};
 use pyo3::{
     class::basic::PyObjectProtocol,
     exceptions::{LookupError, RuntimeError},
     prelude::*,
-    types::{PyFloat, PyLong, PyTuple},
+    types::{PyDict, PyFloat, PyLong, PyTuple},
     ToPyObject,
 };
 use std::{cmp::Ordering, convert::From, rc::Rc, slice};
 use wasmer_runtime::{self as runtime, Value as WasmValue};
-use wasmer_runtime_core::{instance::DynFunc, types::Type};
+use wasmer_runtime_core::{instance::DynFunc, types::Type as WasmType};
 
 #[repr(u8)]
 pub enum ExportImportKind {
@@ -71,7 +70,7 @@ pub struct ExportedFunction {
 
 /// Implement the `InspectExportedFunction` trait.
 impl InspectExportedFunction for ExportedFunction {
-    fn move_runtime_func_obj(&self) -> Result<DynFunc, PyErr> {
+    fn function(&self) -> PyResult<DynFunc> {
         match self.instance.dyn_func(&self.function_name) {
             Ok(function) => Ok(function),
             Err(_) => Err(RuntimeError::py_err(format!(
@@ -79,20 +78,6 @@ impl InspectExportedFunction for ExportedFunction {
                 self.function_name
             ))),
         }
-    }
-
-    fn signature(&self) -> String {
-        let function = &self.move_runtime_func_obj().unwrap();
-        let signature = function.signature();
-
-        format!("{}: {:?}", &self.function_name, signature)
-    }
-
-    fn params(&self) -> String {
-        let function = &self.move_runtime_func_obj().unwrap();
-        let signature = function.signature();
-
-        format!("{}: {:?}", &self.function_name, signature.params())
     }
 }
 
@@ -136,11 +121,19 @@ pub(super) fn call_dyn_func(
         let value = match argument.downcast_ref::<Value>() {
             Ok(value) => value.value.clone(),
             Err(_) => match parameter {
-                Type::I32 => WasmValue::I32(argument.downcast_ref::<PyLong>()?.extract::<i32>()?),
-                Type::I64 => WasmValue::I64(argument.downcast_ref::<PyLong>()?.extract::<i64>()?),
-                Type::F32 => WasmValue::F32(argument.downcast_ref::<PyFloat>()?.extract::<f32>()?),
-                Type::F64 => WasmValue::F64(argument.downcast_ref::<PyFloat>()?.extract::<f64>()?),
-                Type::V128 => {
+                WasmType::I32 => {
+                    WasmValue::I32(argument.downcast_ref::<PyLong>()?.extract::<i32>()?)
+                }
+                WasmType::I64 => {
+                    WasmValue::I64(argument.downcast_ref::<PyLong>()?.extract::<i64>()?)
+                }
+                WasmType::F32 => {
+                    WasmValue::F32(argument.downcast_ref::<PyFloat>()?.extract::<f32>()?)
+                }
+                WasmType::F64 => {
+                    WasmValue::F64(argument.downcast_ref::<PyFloat>()?.extract::<f64>()?)
+                }
+                WasmType::V128 => {
                     WasmValue::V128(argument.downcast_ref::<PyLong>()?.extract::<u128>()?)
                 }
             },
@@ -171,28 +164,57 @@ pub(super) fn call_dyn_func(
 #[pymethods]
 /// Implement methods on the `ExportedFunction` Python class.
 impl ExportedFunction {
-    #[call]
-    #[args(arguments = "*")]
     // The `ExportedFunction.__call__` method.
     // The `#[args(arguments = "*")]` means that the method has an
     // unfixed arity. All parameters will be received in the
     // `arguments` argument.
+    #[call]
+    #[args(arguments = "*")]
     fn __call__(&self, py: Python, arguments: &PyTuple) -> PyResult<PyObject> {
-        // Get the exported function.
-        let function: DynFunc = self.move_runtime_func_obj().unwrap();
-
-        call_dyn_func(py, &self.function_name, function, arguments)
+        call_dyn_func(py, &self.function_name, self.function()?, arguments)
     }
 
-    #[getter]
     // On the blueprint of Python's `inpect.getfullargspec`
-    fn getfullargspec(&self) -> PyResult<String> {
-        Ok(self.signature())
-    }
-
     #[getter]
-    fn getargs(&self) -> PyResult<String> {
-        Ok(self.params())
+    fn getfullargspec(&self, py: Python) -> PyResult<PyObject> {
+        let function = self.function()?;
+        let signature = function.signature();
+        let annotations = PyDict::new(py);
+
+        for (nth, ty) in &signature
+            .params()
+            .iter()
+            .enumerate()
+            .map(|(nth, ty)| (nth, ty.into()))
+            .collect::<Vec<(usize, Type)>>()
+        {
+            annotations.set_item(format!("x{}", nth), ty)?;
+        }
+
+        let args = annotations.keys();
+
+        for ty in &signature
+            .returns()
+            .iter()
+            .map(Into::into)
+            .collect::<Vec<Type>>()
+        {
+            annotations.set_item("return", ty)?;
+        }
+
+        let inspect = py.import("inspect")?;
+        let args: Py<PyTuple> = (
+            args,
+            py.None(), // varargs
+            py.None(), // varkw
+            py.None(), // defaults
+            py.None(), // kwonlyargs
+            py.None(), // kwonlydefaults
+            annotations,
+        )
+            .into_py(py);
+
+        Ok(inspect.call1("FullArgSpec", args)?.to_object(py))
     }
 }
 

--- a/src/instance/inspect.rs
+++ b/src/instance/inspect.rs
@@ -10,11 +10,5 @@ use wasmer_runtime_core::instance::DynFunc;
 pub trait InspectExportedFunction {
     // A convenience method to move Wasmer runtime's dynamic function
     // object into scope for pyo3 constructors/callers
-    fn move_runtime_func_obj(&self) -> Result<DynFunc, PyErr>;
-
-    // Returns the signature of an exported function.
-    fn signature(&self) -> String;
-
-    // Returns the parameters of an exporterd function.
-    fn params(&self) -> String;
+    fn function(&self) -> PyResult<DynFunc>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,12 @@ use pyo3::{prelude::*, types::PyTuple};
 mod instance;
 mod memory;
 mod module;
+mod r#type;
 mod value;
 
 use instance::{exports::ExportImportKind, Instance};
 use module::Module;
+use r#type::Type;
 use value::Value;
 
 /// This extension allows to manipulate and to execute WebAssembly binaries.
@@ -30,27 +32,44 @@ fn wasmer(py: Python, module: &PyModule) -> PyResult<()> {
 
     {
         let enum_module = py.import("enum")?;
-        let mut variants = String::new();
 
-        for kind in ExportImportKind::iter() {
-            variants.push_str(kind.into());
-            variants.push(' ');
+        {
+            let mut variants = String::new();
+
+            for ty in Type::iter() {
+                variants.push_str(ty.into());
+                variants.push(' ');
+            }
+
+            module.add(
+                "Type",
+                enum_module.call1("IntEnum", PyTuple::new(py, &["Type", variants.as_str()]))?,
+            )?;
         }
 
-        module.add(
-            "ExportKind",
-            enum_module.call1(
-                "IntEnum",
-                PyTuple::new(py, &["ExportKind", variants.as_str()]),
-            )?,
-        )?;
-        module.add(
-            "ImportKind",
-            enum_module.call1(
-                "IntEnum",
-                PyTuple::new(py, &["ImportKind", variants.as_str()]),
-            )?,
-        )?;
+        {
+            let mut variants = String::new();
+
+            for kind in ExportImportKind::iter() {
+                variants.push_str(kind.into());
+                variants.push(' ');
+            }
+
+            module.add(
+                "ExportKind",
+                enum_module.call1(
+                    "IntEnum",
+                    PyTuple::new(py, &["ExportKind", variants.as_str()]),
+                )?,
+            )?;
+            module.add(
+                "ImportKind",
+                enum_module.call1(
+                    "IntEnum",
+                    PyTuple::new(py, &["ImportKind", variants.as_str()]),
+                )?,
+            )?;
+        }
     }
 
     Ok(())

--- a/src/module.rs
+++ b/src/module.rs
@@ -127,10 +127,10 @@ impl Module {
             dict.set_item(
                 "kind",
                 match export_index {
-                    ExportIndex::Func(_) => ExportImportKind::Function as u8,
-                    ExportIndex::Memory(_) => ExportImportKind::Memory as u8,
-                    ExportIndex::Global(_) => ExportImportKind::Global as u8,
-                    ExportIndex::Table(_) => ExportImportKind::Table as u8,
+                    ExportIndex::Func(_) => ExportImportKind::Function,
+                    ExportIndex::Memory(_) => ExportImportKind::Memory,
+                    ExportIndex::Global(_) => ExportImportKind::Global,
+                    ExportIndex::Table(_) => ExportImportKind::Table,
                 },
             )?;
             dict.set_item("name", name)?;

--- a/src/type.rs
+++ b/src/type.rs
@@ -1,0 +1,58 @@
+//! The `Value` Python class to build WebAssembly values.
+
+use pyo3::prelude::*;
+use std::slice;
+use wasmer_runtime_core::types::Type as WasmType;
+
+#[repr(u8)]
+pub enum Type {
+    I32,
+    I64,
+    F32,
+    F64,
+    V128,
+}
+
+impl Type {
+    pub fn iter() -> slice::Iter<'static, Type> {
+        static VARIANTS: [Type; 5] = [Type::I32, Type::I64, Type::F32, Type::F64, Type::V128];
+
+        VARIANTS.iter()
+    }
+}
+
+impl From<&Type> for &'static str {
+    fn from(value: &Type) -> Self {
+        match value {
+            Type::I32 => "I32",
+            Type::I64 => "I64",
+            Type::F32 => "F32",
+            Type::F64 => "F64",
+            Type::V128 => "V128",
+        }
+    }
+}
+
+impl From<&WasmType> for Type {
+    fn from(ty: &WasmType) -> Self {
+        match ty {
+            WasmType::I32 => Type::I32,
+            WasmType::I64 => Type::I64,
+            WasmType::F32 => Type::F32,
+            WasmType::F64 => Type::F64,
+            WasmType::V128 => Type::V128,
+        }
+    }
+}
+
+impl ToPyObject for Type {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            Type::I32 => (Type::I32 as u8).into_py(py),
+            Type::I64 => (Type::I64 as u8).into_py(py),
+            Type::F32 => (Type::F32 as u8).into_py(py),
+            Type::F64 => (Type::F64 as u8).into_py(py),
+            Type::V128 => (Type::V128 as u8).into_py(py),
+        }
+    }
+}

--- a/src/type.rs
+++ b/src/type.rs
@@ -6,11 +6,11 @@ use wasmer_runtime_core::types::Type as WasmType;
 
 #[repr(u8)]
 pub enum Type {
-    I32,
-    I64,
-    F32,
-    F64,
-    V128,
+    I32 = 1,
+    I64 = 2,
+    F32 = 3,
+    F64 = 4,
+    V128 = 5,
 }
 
 impl Type {

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,5 +1,5 @@
 import wasmer
-from wasmer import Instance, Uint8Array, Value
+from wasmer import Instance, Uint8Array, Value, Type
 import inspect
 import os
 import pytest
@@ -76,7 +76,15 @@ def test_memory_view():
 
 def test_getfullargspec():
     instance = Instance(TEST_BYTES)
-    assert instance.exports.sum.getfullargspec == inspect.FullArgSpec(args=['x0', 'x1'], varargs=None, varkw=None, defaults=None, kwonlyargs=None, kwonlydefaults=None, annotations={'x0': 0, 'x1': 0, 'return': 0})
+    assert instance.exports.sum.getfullargspec == inspect.FullArgSpec(
+        args=['x0', 'x1'],
+        varargs=None,
+        varkw=None,
+        defaults=None,
+        kwonlyargs=None,
+        kwonlydefaults=None,
+        annotations={'x0': Type.I32, 'x1': Type.I32, 'return': Type.I32}
+    )
 
 def test_resolve_exported_function():
     assert Instance(TEST_BYTES).resolve_exported_function(0) == "sum"

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -76,11 +76,7 @@ def test_memory_view():
 
 def test_getfullargspec():
     instance = Instance(TEST_BYTES)
-    assert instance.exports.sum.getfullargspec == "sum: FuncSig { params: [I32, I32], returns: [I32] }"
-
-def test_getargs():
-    instance = Instance(TEST_BYTES)
-    assert instance.exports.sum.getargs == "sum: [I32, I32]"
+    assert instance.exports.sum.getfullargspec == inspect.FullArgSpec(args=['x0', 'x1'], varargs=None, varkw=None, defaults=None, kwonlyargs=None, kwonlydefaults=None, annotations={'x0': 0, 'x1': 0, 'return': 0})
 
 def test_resolve_exported_function():
     assert Instance(TEST_BYTES).resolve_exported_function(0) == "sum"

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -1,0 +1,11 @@
+from wasmer import Type
+from enum import IntEnum
+
+def test_type():
+    assert issubclass(Type, IntEnum)
+    assert len(Type) == 5
+    assert Type.I32 == 1
+    assert Type.I64 == 2
+    assert Type.F32 == 3
+    assert Type.F64 == 4
+    assert Type.V128 == 5


### PR DESCRIPTION
This PR updates `ExportedFunction.getfullargspec` to return a  `FullArgSpec` named tupled, as in the `inspect` module strictly.

Thus, it introduces the `Type` int enum.

It also updates the `ExportImportKind` int enum to implement the `ToPyObject` trait.

The `ExportedFunction.getargs` function has been removed, since it no longer makes sense.