### PR TITLE
test(ci) Update according to last changes in the `release` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,9 +110,10 @@ jobs:
           export PATH="$HOME/.pyenv/versions/$(cat .python-version)/bin:$PATH"
           if test -d .env/bin/; then source .env/bin/activate; else source .env/Scripts/activate; fi
           maturin list-python
-          echo "Selected interpreter: $(maturin list-python | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')"
-          just build
-          just build-any
+          PYTHON_INTERPRETER=$(maturin list-python | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
+          echo "Selected interpreter: ${PYTHON_INTERPRETER}"
+          just build "${{ matrix.target.rust-target }}"
+          just build-any-wheel
 
       - name: Run all the tests
         shell: bash

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ build_features := ""
 
 # Compile and install the Python library.
 # Run with `--set build_features` to compile with specific Cargo features.
-build:
+build rust_target='':
         #!/usr/bin/env bash
         export PYTHON_SYS_EXECUTABLE=$(which python)
 
@@ -56,6 +56,10 @@ build:
 
         if test ! -z "${build_features}"; then
                 build_args="--no-default-features --features ${build_features}"
+        fi
+
+        if test ! -z "{{ rust_target }}"; then
+                build_args="${build_args} --target {{ rust_target }}"
         fi
 
         echo "Build arguments: ${build_args}"

--- a/justfile
+++ b/justfile
@@ -113,10 +113,10 @@ inspect:
 	@python -c "help('wasmer')"
 
 publish:
-	twine upload --repository testpypi target/wheels/wasmer-*.whl -u wasmer
+	twine upload --repository pypi target/wheels/wasmer-*.whl -u wasmer
 
 publish-any:
-	twine upload --repository testpypi target/wheels/wasmer-*-py3-none-any.whl -u wasmer
+	twine upload --repository pypi target/wheels/wasmer-*-py3-none-any.whl -u wasmer
 
 # Local Variables:
 # mode: makefile


### PR DESCRIPTION
The CI is broken because I've updated the `release` workflow without testing the `test` workflow. This patch fixes that.

Also the `build` recipe in the `justfile` is updated to receive a Rust target for `rustc`.